### PR TITLE
find the reason

### DIFF
--- a/lua/autorun/acf_globals.lua
+++ b/lua/autorun/acf_globals.lua
@@ -283,15 +283,8 @@ elseif CLIENT then
 
 end
 
-if ACF.AllowCSLua > 0 then
-	AddCSLuaFile("autorun/translation/ace_translationpacks.lua")
-	RunConsoleCommand("sv_allowcslua", 1)
-	include("autorun/translation/ace_translationpacks.lua") -- File that is overwritten to install a translation pack
-else
-	RunConsoleCommand("sv_allowcslua", 0)
-	include("autorun/translation/ace_translationpacks.lua")
-	AddCSLuaFile("autorun/translation/ace_translationpacks.lua")
-end
+AddCSLuaFile("autorun/translation/ace_translationpacks.lua")
+include("autorun/translation/ace_translationpacks.lua")
 
 include("acf/shared/sh_ace_particles.lua")
 include("acf/shared/sh_ace_sound_loader.lua")


### PR DESCRIPTION
acf_globals.lua: Question!
Server Owner: What's your question, acf_globals.lua?
acf_globals.lua: I teleported `sv_allowcslua 0` using `if ACF.AllowCSLua > 0`

not needed, disables sv_allowcslua 0 every time the server starts (shit)